### PR TITLE
Add feature request and bug report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: "🐞 Bug report template"
+about: Please use this template when submitting a bug report
+title: "[BUG] - "
+labels: bug
+assignees: ''
+
+---
+
+# What
+Description of the bug
+
+- When I [open a screen/click on a button], [something unexpected happens].
+
+# How to reproduce the bug
+Please be as specific as you can. Following this list, we can find the problem
+and get back to you faster:
+
+- Browser name and version
+- OS name and version
+- Screenshots, if possible. We'd love these!
+- Where you clicked
+- What happened
+
+Thanks for your feedback! ♡

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,19 @@
+---
+name: "✨ New feature issue template"
+about: "Want something new in the project? Use this template. 🎉"
+title: "[FEATURE] - "
+labels: enhancement
+assignees: ''
+
+---
+
+# What
+Description of the feature you'd like to see in the project.
+
+- As a [persona/role] I want to [action] so that [outcome/benefit].
+- When [users work/life context] I want to [motivation] so that [outcome/benefit].
+
+# Why
+Reason for including this new feature in the project.
+
+Thanks for the feedback! ♡


### PR DESCRIPTION
# What
Add issue templates to the project.

# Why
Basically juuh42dias requested it. :P

These templates are parsed by GitHub when someone opens a new issue in the project. The person can choose which template makes more sense to them and follow the structure we've laid out there, so we standardize the issue opening process.