### PR TITLE
Fix local build infrastructure files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+./.git
+./tmp
+./log
+./node_modules
+./coverage
+./dumps
+./public/system
+./public/assets
+*.log
+./Dockerfile*
+./public/packs
+./public/packs-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,26 @@
-FROM ruby:2.6.2
-RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
+FROM ruby:2.6.4
+ENV BUNDLE_PATH="$GEM_HOME" HISTFILE="$APP_HOME/tmp/docker_histfile"
+
+RUN apt-get update -qq \
+  && apt-get install -y --no-install-recommends nodejs postgresql-client cmake npm \
+  && npm install -g yarn
+
 RUN mkdir /transervicos
 WORKDIR /transervicos
 RUN gem install bundler:2.0.1
 COPY Gemfile /transervicos/Gemfile
 COPY Gemfile.lock /transervicos/Gemfile.lock
-RUN bundle install
 COPY . /transervicos
+
+# Install gems using Bundler
+RUN bundle check || (bundle install --no-cache --jobs=2 \
+      && bundle clean --force \
+      && rm -rf "$BUNDLE_PATH/gems/*/.git" \
+      && rm -rf "$BUNDLE_PATH/bundler/gems/*/.git")
+
+# Install JS packages using Yarn
+COPY package.json yarn.lock /transervicos/
+RUN yarn install && yarn cache clean
 
 # Add a script to be executed every time the container starts.
 COPY entrypoint.sh /usr/bin/

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -19,9 +19,10 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: localhost
-  port: 5432
+  host: db
+  username: postgres
+  password:
+  pool: 5
 
 development:
   <<: *default


### PR DESCRIPTION
# What
- Added .dockerignore
- Adjusted `config/database.yml.example` so a new copy can connect to the development database
- Adjusted the `Dockerfile`.

# Why
We had several problems when running `docker-compose build`, which builds the containers, and consequently `docker-compose up`. First off, `docker-compose up` didn't work in the way the repo was set up previously and we couldn't build the local container either.

We also updated the Ruby image in the Dockerfile to reflect the version specified in the Gemfile. Besides that, we included a .dockerignore file, which speeds up the build process.

This whole fix involved a series of steps. We adjusted Bundler, the OS used in the Ruby image ,Yarn installations, and the database.yml.example file. Now we should be able to bring up a container from zero in our local environment without any problems.