### PR TITLE
Update project URL in the tweet button

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -105,7 +105,7 @@
                   <div class="pull-left fb-share-button" data-href="wwww.transervicos.org" data-layout="button"></div>
                   <div class="pull-left" style="margin-left: 7px;">
                     <a class="twitter-share-button"
-                      href="https://twitter.com/intent/tweet?text=Conhe&ccedil;a o Transervi&ccedil;os - servi&ccedil;os para pessoas trans e travestis http://transervicos.herokuapp.com/">
+                      href="https://twitter.com/intent/tweet?text=Conhe&ccedil;a o Transervi&ccedil;os - servi&ccedil;os para pessoas trans e travestis http://www.transervicos.org">
                     Tweet</a>
                   </div>
           			</div>


### PR DESCRIPTION
Right now the URL is redirected to the previous domain the project was using. This PR aims to update it using the current one