### PR TITLE
feat: add 'testing' to readme-en

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -58,4 +58,11 @@ To run the application, run:
 
 # Testing
 
-## PENDING
+*  `bundle install` para instalar o Rspec, que está no gemfile.
+
+**Running everything at once:**  `bundle exec rspec`
+> Runs all your tests.
+**Running one RSpec file at a time:** `bundle exec rspec ./spec/models/my_file.rb.`
+> Runs only tests in `my_file`.
+**Running one specific test:**  `bundle exec rspec ./spec/models/my_file.rb:10`
+> Runs only tests on line 10 in `my_file`.

--- a/README-EN.md
+++ b/README-EN.md
@@ -62,7 +62,9 @@ To run the application, run:
 
 **Running everything at once:**  `bundle exec rspec`
 > Runs all your tests.
+
 **Running one RSpec file at a time:** `bundle exec rspec ./spec/models/my_file.rb.`
 > Runs only tests in `my_file`.
+
 **Running one specific test:**  `bundle exec rspec ./spec/models/my_file.rb:10`
 > Runs only tests on line 10 in `my_file`.

--- a/README.md
+++ b/README.md
@@ -67,13 +67,4 @@ Caso você esteja utilizando Docker, basta executar `docker-compose up`. A aplic
 
 # Rodando testes
 
-*  `bundle install` para instalar o Rspec, que está no gemfile.
-
-**Para executar todos os testes:**  `bundle exec rspec`
-> Executa todos os testes da pasta `spec`.
-
-**Para executar os testes de um único arquivo:** `bundle exec rspec ./spec/models/my_file.rb.`
-> Executa todos os testes do arquivo `my_file`.
-
-**Para executar um teste específico:**  `bundle exec rspec ./spec/models/my_file.rb:10`
-> Executa o teste na linha 10 do `my_file`.
+## PENDENTE

--- a/README.md
+++ b/README.md
@@ -67,4 +67,13 @@ Caso você esteja utilizando Docker, basta executar `docker-compose up`. A aplic
 
 # Rodando testes
 
-## PENDENTE
+*  `bundle install` para instalar o Rspec, que está no gemfile.
+
+**Para executar todos os testes:**  `bundle exec rspec`
+> Executa todos os testes da pasta `spec`.
+
+**Para executar os testes de um único arquivo:** `bundle exec rspec ./spec/models/my_file.rb.`
+> Executa todos os testes do arquivo `my_file`.
+
+**Para executar um teste específico:**  `bundle exec rspec ./spec/models/my_file.rb:10`
+> Executa o teste na linha 10 do `my_file`.


### PR DESCRIPTION
# O que
Adiciona descrição para a seção "testing" do readme-en.

# Por que
Para que os desenvolvedores possam saber como rodar os testes.